### PR TITLE
Change the bene features hub page to have installation buttons etc

### DIFF
--- a/bene_features.routing.yml
+++ b/bene_features.routing.yml
@@ -2,7 +2,7 @@
 bene.feature.config:
   path: '/admin/config/bene_features'
   defaults:
-    _controller: '\Drupal\system\Controller\SystemController::systemAdminMenuBlockPage'
+    _controller: '\Drupal\bene_features\Controller\BeneFeaturesController::configPage'
     _title: 'Bene Features'
   requirements:
     _permission: 'configure bene features'

--- a/bene_features.routing.yml
+++ b/bene_features.routing.yml
@@ -6,3 +6,12 @@ bene.feature.config:
     _title: 'Bene Features'
   requirements:
     _permission: 'configure bene features'
+
+bene.feature.set:
+  path: '/admin/config/bene_features/{action}/{module}'
+  defaults:
+    _controller: '\Drupal\bene_features\Controller\BeneFeaturesController::setModule'
+    _title: 'Bene Features Enable/Disable'
+  requirements:
+    _permission: 'configure bene features'
+    _csrf_token: 'TRUE'

--- a/modules/bene_features_example/bene_features_example.module
+++ b/modules/bene_features_example/bene_features_example.module
@@ -19,6 +19,13 @@ function bene_features_example_help($route_name, RouteMatchInterface $route_matc
         'details' => [
           '#markup' => t('Example help page for Bene Features Example.'),
         ],
+        'video' => [
+          '#type' => 'inline_template',
+          '#template' => '{{ helpvideo | raw }}',
+          '#context' => [
+            'helpvideo' => '<div><iframe width="441" height="331" src="https://www.youtube.com/embed/Otbml6WIQPo" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe></div>',
+          ],
+        ],
       ];
       break;
 

--- a/modules/bene_features_example/bene_features_example.module
+++ b/modules/bene_features_example/bene_features_example.module
@@ -20,10 +20,10 @@ function bene_features_example_help($route_name, RouteMatchInterface $route_matc
           '#markup' => '<p>' . t('Example help page for Bene Features Example.') . '</p>',
         ],
         'video' => [
-          '#type' => 'inline_template',
-          '#template' => '{{ helpvideo | raw }}',
-          '#context' => [
-            'helpvideo' => '<div><iframe width="441" height="331" src="https://www.youtube.com/embed/Otbml6WIQPo" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe></div>',
+          '#type' => 'markup',
+          '#markup' => '<div><iframe width="441" height="331" src="https://www.youtube.com/embed/Otbml6WIQPo" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe></div>',
+          '#allowed_tags' => [
+            'iframe',
           ],
         ],
       ];

--- a/modules/bene_features_example/bene_features_example.module
+++ b/modules/bene_features_example/bene_features_example.module
@@ -17,7 +17,7 @@ function bene_features_example_help($route_name, RouteMatchInterface $route_matc
     case 'help.page.bene_features_example':
       $page = [
         'details' => [
-          '#markup' => t('Example help page for Bene Features Example.'),
+          '#markup' => '<p>' . t('Example help page for Bene Features Example.') . '</p>',
         ],
         'video' => [
           '#type' => 'inline_template',

--- a/src/Controller/BeneFeaturesController.php
+++ b/src/Controller/BeneFeaturesController.php
@@ -1,0 +1,167 @@
+<?php
+
+namespace Drupal\bene_features\Controller;
+
+use Drupal\Core\Controller\ControllerBase;
+use Drupal\Core\Extension\Extension;
+use Drupal\Core\Messenger\MessengerInterface;
+use Drupal\Core\Url;
+
+/**
+ * Provides feature installation interface for Bene.
+ *
+ * @internal
+ */
+class BeneFeaturesController extends ControllerBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function configPage() {
+    $modules = system_rebuild_module_data();
+    $uninstall = \Drupal::request()->query->get('remove') ?: FALSE;
+    if ($uninstall) {
+      // Validate the uninstall string before attempting uninstall:
+      if (isset($modules['bene_' . $uninstall]) && $modules['bene_' . $uninstall]->status) {
+        if (\Drupal::service('module_installer')->uninstall(['bene_' . $uninstall])) {
+          \Drupal::messenger()->addMessage(
+            t('%module has been disabled. You may re-enable it below.', ['%module' => $modules['bene_' . $uninstall]->info['name']]),
+            MessengerInterface::TYPE_STATUS
+          );
+        }
+      }
+      // Clean up the URL and refresh the module status list in the process.
+      return $this->redirect('bene.feature.config');
+    }
+    $install = \Drupal::request()->query->get('install') ?: FALSE;
+    if ($install) {
+      // Validate the install string before attempting install:
+      if (isset($modules['bene_' . $install]) && !$modules['bene_' . $install]->status) {
+        if (\Drupal::service('module_installer')->install(['bene_' . $install])) {
+          \Drupal::messenger()->addMessage(
+            t('%module has been enabled. Return to this page when you are ready to disable it.', ['%module' => $modules['bene_' . $install]->info['name']]),
+            MessengerInterface::TYPE_STATUS
+          );
+        }
+      }
+      // Clean up the URL and refresh the module status list in the process.
+      return $this->redirect('bene.feature.config');
+    }
+
+    $page = [
+      'enabled' => [
+        '#type' => 'table',
+        '#header' => [
+          t('Enabled Features'),
+          t('About'),
+          t('Options'),
+        ],
+        '#empty' => t('You do not have any Bene Features enabled. Enable any Bene Features you wan to use below.'),
+      ],
+      'disabled' => [
+        '#type' => 'table',
+        '#header' => [
+          t('Disabled Features'),
+          t('About'),
+          t('Options'),
+        ],
+        '#empty' => t('You do not have any disabled Bene Features, but if new Bene Features are added to Bene they will appear here.'),
+      ],
+    ];
+
+    // Find all the Bene Features modules.
+    foreach ($modules as $filename => $module) {
+      if (empty($module->info['hidden'])) {
+        if ($module->info['package'] === 'Bene Features' && $module->getName() != 'bene_features') {
+          if ($module->status) {
+            $page['enabled'][] = $this->buildEnabledRow($module);
+          }
+          else {
+            $page['disabled'][] = $this->buildDisabledRow($module);
+          }
+        }
+      }
+    }
+
+    return $page;
+  }
+
+  /**
+   * Builds a table row for the Bene Features page for an Enabled module.
+   *
+   * @param \Drupal\Core\Extension\Extension $module
+   *   The module for which to build the form row.
+   *
+   * @return array
+   *   The form row for the given module.
+   */
+  protected function buildEnabledRow(Extension $module) {
+    $row['title'] = [
+      '#markup' => $module->info['name'],
+    ];
+    $row['description'][] = [
+      '#markup' => $module->info['description'],
+    ];
+    // Generate link for module's configuration page, if it has one.
+    if (isset($module->info['configure'])) {
+      $route_parameters = isset($module->info['configure_parameters']) ? $module->info['configure_parameters'] : [];
+      $row['description'][] = [
+        '#type' => 'link',
+        '#title' => $this->t('Configure <span class="visually-hidden">the @module module</span>', ['@module' => $module->info['name']]),
+        '#url' => Url::fromRoute($module->info['configure'], $route_parameters),
+        '#prefix' => '<br/>',
+        '#options' => [
+          'attributes' => [
+            'class' => ['module-link', 'module-link-configure'],
+          ],
+          'query' => [
+            'destination' => Url::fromRoute('bene.feature.config')->toString(),
+          ],
+        ],
+      ];
+    }
+    $row['options'] = [
+      '#type' => 'link',
+      '#title' => $this->t('Disable <span class="visually-hidden">the @module module</span>', ['@module' => $module->info['name']]),
+      '#url' => Url::fromRoute('bene.feature.config', [], ['query' => ['remove' => substr($module->getName(), 5)]]),
+      '#options' => [
+        'attributes' => [
+          'class' => ['button', 'button--small'],
+        ],
+      ],
+    ];
+
+    return $row;
+  }
+
+  /**
+   * Builds a table row for the Bene Features page for a disabled module.
+   *
+   * @param \Drupal\Core\Extension\Extension $module
+   *   The module for which to build the form row.
+   *
+   * @return array
+   *   The form row for the given module.
+   */
+  protected function buildDisabledRow(Extension $module) {
+    $row['title'] = [
+      '#markup' => $module->info['name'],
+    ];
+    $row['description'] = [
+      '#markup' => $module->info['description'],
+    ];
+    $row['options'] = [
+      '#type' => 'link',
+      '#title' => $this->t('Enable <span class="visually-hidden">the @module module</span>', ['@module' => $module->info['name']]),
+      '#url' => Url::fromRoute('bene.feature.config', [], ['query' => ['install' => substr($module->getName(), 5)]]),
+      '#options' => [
+        'attributes' => [
+          'class' => ['button', 'button--primary', 'button--small'],
+        ],
+      ],
+    ];
+
+    return $row;
+  }
+
+}

--- a/src/Controller/BeneFeaturesController.php
+++ b/src/Controller/BeneFeaturesController.php
@@ -99,13 +99,13 @@ class BeneFeaturesController extends ControllerBase {
     $row['title'] = [
       '#markup' => $module->info['name'],
     ];
-    $row['description'][] = [
+    $row['description']['description'] = [
       '#markup' => $module->info['description'],
     ];
     // Generate link for module's configuration page, if it has one.
     if (isset($module->info['configure'])) {
       $route_parameters = isset($module->info['configure_parameters']) ? $module->info['configure_parameters'] : [];
-      $row['description'][] = [
+      $row['description']['configure'] = [
         '#type' => 'link',
         '#title' => $this->t('Configure <span class="visually-hidden">the @module module</span>', ['@module' => $module->info['name']]),
         '#url' => Url::fromRoute($module->info['configure'], $route_parameters),
@@ -119,6 +119,22 @@ class BeneFeaturesController extends ControllerBase {
           ],
         ],
       ];
+      // Generate link for module's help page. Assume that if a hook_help()
+      // implementation exists then the module provides an overview page, rather
+      // than checking to see if the page exists, which is costly.
+      if (\Drupal::service('module_handler')->moduleExists('help') && $module->status && in_array($module->getName(), \Drupal::service('module_handler')->getImplementations('help'))) {
+        $row['description']['help'] = [
+          '#type' => 'link',
+          '#title' => $this->t('Help'),
+          '#url' => Url::fromRoute('help.page', ['name' => $module->getName()]),
+          '#options' => [
+            'attributes' => [
+              'class' => ['module-link', 'module-link-help'],
+              'title' => $this->t('Help'),
+            ],
+          ],
+        ];
+      }
     }
     $row['options'] = [
       '#type' => 'link',

--- a/src/Controller/BeneFeaturesController.php
+++ b/src/Controller/BeneFeaturesController.php
@@ -65,7 +65,7 @@ class BeneFeaturesController extends ControllerBase {
           t('About'),
           t('Options'),
         ],
-        '#empty' => t('You do not have any disabled Bene Features, but if new Bene Features are added to Bene they will appear here.'),
+        '#empty' => t('You do not have any disabled Bene Features, but if new Bene Features are added to Bene they will appear here. (You might want to disable "Features Example" as it doesn\'t really do anything)'),
       ],
     ];
 

--- a/src/Controller/BeneFeaturesController.php
+++ b/src/Controller/BeneFeaturesController.php
@@ -15,43 +15,10 @@ use Drupal\Core\Url;
 class BeneFeaturesController extends ControllerBase {
 
   /**
-   * {@inheritdoc}
-   */
-  public function setModule(String $action, String $module) {
-    $modules = system_rebuild_module_data();
-    switch ($action) {
-      case 'remove':
-        // Validate the uninstall string before attempting uninstall:
-        if (isset($modules['bene_' . $module]) && $modules['bene_' . $module]->status) {
-          if (\Drupal::service('module_installer')
-            ->uninstall(['bene_' . $module])) {
-            \Drupal::messenger()->addMessage(
-              t('%module has been disabled. You may re-enable it below.', ['%module' => $modules['bene_' . $module]->info['name']]),
-              MessengerInterface::TYPE_STATUS
-            );
-          }
-        }
-        break;
-
-      case 'install':
-        // Validate the install string before attempting install:
-        if (isset($modules['bene_' . $module]) && !$modules['bene_' . $module]->status) {
-          if (\Drupal::service('module_installer')
-            ->install(['bene_' . $module])) {
-            \Drupal::messenger()->addMessage(
-              t('%module has been enabled. Return to this page when you are ready to disable it.', ['%module' => $modules['bene_' . $module]->info['name']]),
-              MessengerInterface::TYPE_STATUS
-            );
-          }
-        }
-        break;
-
-    }
-    return $this->redirect('bene.feature.config');
-  }
-
-  /**
-   * {@inheritdoc}
+   * A page listing Bene Feature modules and providing control links.
+   *
+   * @return array
+   *   Render array for the config page.
    */
   public function configPage() {
     $modules = system_rebuild_module_data();
@@ -92,6 +59,50 @@ class BeneFeaturesController extends ControllerBase {
     }
 
     return $page;
+  }
+
+  /**
+   * A CSRF-protected route that performs the module enable/disable actions.
+   *
+   * @param string $action
+   *   Either "remove" or "install".
+   * @param string $module
+   *   The name of a bene features module, with the "bene_" prefix removed.
+   *
+   * @return \Symfony\Component\HttpFoundation\RedirectResponse
+   *   A redirect response object to go back to the config page.
+   */
+  public function setModule(string $action, string $module) {
+    $modules = system_rebuild_module_data();
+    switch ($action) {
+      case 'remove':
+        // Validate the uninstall string before attempting uninstall:
+        if (isset($modules['bene_' . $module]) && $modules['bene_' . $module]->status) {
+          if (\Drupal::service('module_installer')
+            ->uninstall(['bene_' . $module])) {
+            \Drupal::messenger()->addMessage(
+              t('%module has been disabled. You may re-enable it below.', ['%module' => $modules['bene_' . $module]->info['name']]),
+              MessengerInterface::TYPE_STATUS
+            );
+          }
+        }
+        break;
+
+      case 'install':
+        // Validate the install string before attempting install:
+        if (isset($modules['bene_' . $module]) && !$modules['bene_' . $module]->status) {
+          if (\Drupal::service('module_installer')
+            ->install(['bene_' . $module])) {
+            \Drupal::messenger()->addMessage(
+              t('%module has been enabled. Return to this page when you are ready to disable it.', ['%module' => $modules['bene_' . $module]->info['name']]),
+              MessengerInterface::TYPE_STATUS
+            );
+          }
+        }
+        break;
+
+    }
+    return $this->redirect('bene.feature.config');
   }
 
   /**


### PR DESCRIPTION
@mariacha or @mortenson any interest in having a look at this? The existence of the sample module makes this page a little easier to try out if you want to do that. Probably easiest to test by also grabbing [`bene_features` branch](https://github.com/thinkshout/bene_promo_redirect/tree/bene_features) of `bene_promo_redirect`.

The install/uninstall behavior here is a little freewheeling, perhaps, but it is locked out of impacting any module outside the `bene_` namespace.